### PR TITLE
Append `viewKeys` to request when creating Flags

### DIFF
--- a/LDConfig.py
+++ b/LDConfig.py
@@ -115,8 +115,8 @@ class LDConfig:
         }
         if "TargetProjectKey" in target:
             settings["target_project_key"] = target["TargetProjectKey"]
-        if "TargetView" in target:
-            settings["target_view"] = target["TargetView"]
+        if "TargetViews" in target:
+            settings["target_views"] = target["TargetViews"]
         if "MigrateFlagTemplates" in options:
             settings["migrate_flag_templates"] = self.to_bool[options["MigrateFlagTemplates"]]
         if "MigrateContextKinds" in options:

--- a/LDConfig.py
+++ b/LDConfig.py
@@ -67,7 +67,7 @@ class LDConfig:
         else:
             if source["SourceProjectKey"] == "":
                 self.error_messages.append("SourceProjectKey cannot be empty")
-        
+
         if not source["SourceApiToken"]:
             self.error_messages.append("SourceApiToken is required")
         else:
@@ -115,6 +115,8 @@ class LDConfig:
         }
         if "TargetProjectKey" in target:
             settings["target_project_key"] = target["TargetProjectKey"]
+        if "TargetView" in target:
+            settings["target_view"] = target["TargetView"]
         if "MigrateFlagTemplates" in options:
             settings["migrate_flag_templates"] = self.to_bool[options["MigrateFlagTemplates"]]
         if "MigrateContextKinds" in options:
@@ -163,6 +165,5 @@ class LDConfig:
             self.error_messages.append("Cannot specify both FlagsToIgnore and FlagsToMigrate.")
             self.is_valid = False
             return
-            
 
         return settings

--- a/LDMigrate.py
+++ b/LDMigrate.py
@@ -58,7 +58,7 @@ class LDMigrate:
         migrate_segments=True,
         migrate_metrics=True,
         ignore_pauses=False,
-        target_view=None,
+        target_views=None,
     ):
         self.api_key_src = api_key_src
         self.api_key_tgt = api_key_tgt
@@ -86,7 +86,7 @@ class LDMigrate:
         self.migrate_segments = migrate_segments
         self.migrate_metrics = migrate_metrics
         self.ignore_pauses = ignore_pauses
-        self.target_view = target_view
+        self.target_views = target_views
 
     def migrate(self):
         # self.get_source_release_pipelines()
@@ -1166,8 +1166,8 @@ class LDMigrate:
                     payload["maintainerId"] = self.target_members[
                         flag["_maintainer"]["email"]
                     ]
-            if self.target_view:
-                payload["viewKeys"] = [self.target_view]
+            if self.target_views:
+                payload["viewKeys"] = [self.target_views]
 
             response = self.http_target.post(
                 "/flags/" + self.project_key_target,

--- a/LDMigrate.py
+++ b/LDMigrate.py
@@ -58,6 +58,7 @@ class LDMigrate:
         migrate_segments=True,
         migrate_metrics=True,
         ignore_pauses=False,
+        target_view=None,
     ):
         self.api_key_src = api_key_src
         self.api_key_tgt = api_key_tgt
@@ -85,6 +86,7 @@ class LDMigrate:
         self.migrate_segments = migrate_segments
         self.migrate_metrics = migrate_metrics
         self.ignore_pauses = ignore_pauses
+        self.target_view = target_view
 
     def migrate(self):
         # self.get_source_release_pipelines()
@@ -1164,6 +1166,8 @@ class LDMigrate:
                     payload["maintainerId"] = self.target_members[
                         flag["_maintainer"]["email"]
                     ]
+            if self.target_view:
+                payload["viewKeys"] = [self.target_view]
 
             response = self.http_target.post(
                 "/flags/" + self.project_key_target,

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ SourceProjectKey=support-service
 TargetApiToken=api-1234567890abcdef
 # TargetProjectKey=fun-little-project
 # TargetIsFederal=false
+# TargetViews=view1,view2
 
 [Options]
 MigrateFlagTemplates=true

--- a/RestAdapter.py
+++ b/RestAdapter.py
@@ -15,7 +15,7 @@ class RestAdapter:
             "Authorization": f"{self.api_token}",
             "Content-Type": "application/json"
         }
-    
+
     def get(self, path, params=None, json=None, beta=False, internal=False):
         return self.request("GET", path, params=params, json=json, beta=beta, internal=internal)
 
@@ -42,7 +42,7 @@ class RestAdapter:
         temp_headers = self.headers.copy()
         if beta:
             temp_headers["LD-API-Version"] = "beta"
-                
+
         retry = 0
         while retry < 5:
             try:

--- a/app.ini.example
+++ b/app.ini.example
@@ -7,6 +7,7 @@ SourceProjectKey=support-service
 TargetApiToken=api-1234567890abcdef
 # TargetProjectKey=fun-little-project
 # TargetIsFederal=false
+# TargetViews=view1,view2
 
 [Options]
 MigrateFlagTemplates=true

--- a/app.py
+++ b/app.py
@@ -22,6 +22,7 @@ ldmigrator = LDMigrate.LDMigrate(
     migrate_payload_filters=settings["migrate_payload_filters"],
     migrate_segments=settings["migrate_segments"],
     migrate_metrics=settings["migrate_metrics"],
+    target_view=settings["target_view"] if "target_view" in settings else None,
 )
 
 result = ldmigrator.migrate()

--- a/app.py
+++ b/app.py
@@ -22,7 +22,7 @@ ldmigrator = LDMigrate.LDMigrate(
     migrate_payload_filters=settings["migrate_payload_filters"],
     migrate_segments=settings["migrate_segments"],
     migrate_metrics=settings["migrate_metrics"],
-    target_view=settings["target_view"] if "target_view" in settings else None,
+    target_views=settings["target_views"] if "target_views" in settings else None,
 )
 
 result = ldmigrator.migrate()


### PR DESCRIPTION
This pull request adds support for specifying and migrating "TargetViews" during the migration process. The changes enable users to define target views in the configuration, pass them through the migration pipeline, and include them in the payload when creating target flags. Documentation and example configuration files are also updated to reflect this new option.

**Support for Target Views in Migration:**

* Added support for reading the `TargetViews` option from the configuration in `LDConfig.py`, storing it in the `settings` dictionary.
* Updated the `LDMigrate` class to accept a `target_views` argument, store it as an instance variable, and include it in the flag creation payload as `viewKeys` if specified. [[1]](diffhunk://#diff-bec29c4a6541d4dd87ef5de92ce3c59da11a31c9b567d0fe74ee9dbf36d2ccb4R61) [[2]](diffhunk://#diff-bec29c4a6541d4dd87ef5de92ce3c59da11a31c9b567d0fe74ee9dbf36d2ccb4R89) [[3]](diffhunk://#diff-bec29c4a6541d4dd87ef5de92ce3c59da11a31c9b567d0fe74ee9dbf36d2ccb4R1169-R1170)
* Modified `app.py` to pass the `target_views` setting to the `LDMigrate` initializer.

**Documentation and Configuration Updates:**

* Updated `README.md` and `app.ini.example` to document the new `TargetViews` configuration option. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R29) [[2]](diffhunk://#diff-d5976555d7ee69377326647ec3a0f23612cc8cdfa538cd7a0d7aed4ec238bbdeR10)